### PR TITLE
fix: skip backup container creation when no shares defined

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -147,10 +147,11 @@ resource "azurerm_backup_container_storage_account" "container" {
   for_each = {
     for policy_name, policy in lookup(var.vault, "policies", {}) != {} ? lookup(var.vault.policies, "file_shares", {}) : {} :
     policy_name => {
-      storage_account_id  = values(policy.protected_shares)[0].storage_account_id
+      storage_account_id  = lookup(policy, "protected_shares", null) != null ? values(policy.protected_shares)[0].storage_account_id : null
       recovery_vault_name = azurerm_recovery_services_vault.vault.name
       resource_group_name = coalesce(try(var.vault.resource_group, null), var.resource_group)
     }
+    if lookup(policy, "protected_shares", null) != null
   }
 
   storage_account_id  = each.value.storage_account_id


### PR DESCRIPTION
## Description

This PR solved the below error while using policy's without container share backups

```
  on ../../main.tf line 150, in resource "azurerm_backup_container_storage_account" "container":
 150:       storage_account_id  = values(policy.protected_shares)[0].storage_account_id

This object does not have an attribute named "protected_shares".}
    deploy_test.go:152: Apply failed for module policies: FatalError{Underlying: error while running command: exit status 1;
        Error: Unsupported attribute

          on ../../main.tf line 150, in resource "azurerm_backup_container_storage_account" "container":
         150:       storage_account_id  = values(policy.protected_shares)[0].storage_account_id
```

The automated tests succeeds now

```
=== NAME  TestApplyAllParallel/protected_vms
    deploy_test.go:141: Cleaning up in: ../examples/protected_vms
=== NAME  TestApplyAllParallel
    deploy_test.go:165: All modules applied and destroyed successfully.
--- PASS: TestApplyAllParallel (0.00s)
    --- PASS: TestApplyAllParallel/default (192.34s)
    --- PASS: TestApplyAllParallel/policies (274.19s)
    --- PASS: TestApplyAllParallel/private-endpoint (437.26s)
    --- PASS: TestApplyAllParallel/protected_file_shares (606.09s)
    --- PASS: TestApplyAllParallel/protected_vms (845.86s)
PASS
ok      github.com/cloudnationhq/terraform-azure-rsv    846.340s
```

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #33