### PR TITLE
feat: add consistency_type to vm backup policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ object({
         name                           = optional(string)
         timezone                       = optional(string, "UTC")
         policy_type                    = optional(string, "V1")
+        consistency_type               = optional(string)
         instant_restore_retention_days = optional(number)
         instant_restore_resource_group = optional(object({
           prefix = string

--- a/main.tf
+++ b/main.tf
@@ -165,6 +165,7 @@ resource "azurerm_backup_policy_vm" "policy" {
   recovery_vault_name            = azurerm_recovery_services_vault.vault.name
   timezone                       = each.value.timezone
   policy_type                    = each.value.policy_type
+  consistency_type               = each.value.consistency_type
   instant_restore_retention_days = each.value.instant_restore_retention_days
 
   dynamic "instant_restore_resource_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -74,6 +74,7 @@ variable "vault" {
         name                           = optional(string)
         timezone                       = optional(string, "UTC")
         policy_type                    = optional(string, "V1")
+        consistency_type               = optional(string)
         instant_restore_retention_days = optional(number)
         instant_restore_resource_group = optional(object({
           prefix = string


### PR DESCRIPTION
## Summary
- Add the optional root-level `consistency_type` attribute to `azurerm_backup_policy_vm`, plumbing it through the `vault.policies.vms` variable schema.
- Per provider docs, `consistency_type` accepts `OnlyCrashConsistent` and is only valid when `policy_type = "V2"`.

## Test plan
- [x] `terraform validate`
- [ ] Existing example modules continue to plan cleanly without setting the new attribute (default `null` preserves prior behavior).

Closes #90