### PR TITLE
feat: add consistency_type to vm backup policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -165,6 +165,7 @@ resource "azurerm_backup_policy_vm" "policy" {
   recovery_vault_name            = azurerm_recovery_services_vault.vault.name
   timezone                       = each.value.timezone
   policy_type                    = each.value.policy_type
+  consistency_type               = each.value.consistency_type
   instant_restore_retention_days = each.value.instant_restore_retention_days
 
   dynamic "instant_restore_resource_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -74,6 +74,7 @@ variable "vault" {
         name                           = optional(string)
         timezone                       = optional(string, "UTC")
         policy_type                    = optional(string, "V1")
+        consistency_type               = optional(string)
         instant_restore_retention_days = optional(number)
         instant_restore_resource_group = optional(object({
           prefix = string
@@ -255,6 +256,22 @@ variable "vault" {
       ) : true
     ])
     error_message = "For VM monthly retention: when include_last_days is true, weekdays and weeks must not be specified."
+  }
+
+  validation {
+    condition = alltrue([
+      for policy_name, policy in coalesce(var.vault.policies.vms, {}) :
+      policy.consistency_type == null || policy.policy_type == "V2"
+    ])
+    error_message = "consistency_type can only be specified when policy_type is V2."
+  }
+
+  validation {
+    condition = alltrue([
+      for policy_name, policy in coalesce(var.vault.policies.vms, {}) :
+      policy.consistency_type == null || policy.consistency_type == "OnlyCrashConsistent"
+    ])
+    error_message = "consistency_type must be 'OnlyCrashConsistent' when specified."
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds the optional `consistency_type` argument to `azurerm_backup_policy_vm`, exposed via `vault.policies.vms.<name>.consistency_type`.
- Adds two validations enforcing provider constraints: the value can only be set when `policy_type = "V2"`, and only `OnlyCrashConsistent` is accepted.

## Test plan
- [x] `terraform validate` passes against the module
- [ ] CI checks pass

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)