### PR TITLE
chore: ignore .terraform.lock.hcl as defense-in-depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Local .terraform directories
 **/.terraform/*
 
+# Terraform dependency lock file
+.terraform.lock.hcl
+**/.terraform.lock.hcl
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ object({
         timezone                       = optional(string, "UTC")
         policy_type                    = optional(string, "V1")
         instant_restore_retention_days = optional(number)
+        consistency_type               = optional(string)
         instant_restore_resource_group = optional(object({
           prefix = string
           suffix = optional(string)

--- a/main.tf
+++ b/main.tf
@@ -166,6 +166,7 @@ resource "azurerm_backup_policy_vm" "policy" {
   timezone                       = each.value.timezone
   policy_type                    = each.value.policy_type
   instant_restore_retention_days = each.value.instant_restore_retention_days
+  consistency_type               = each.value.consistency_type
 
   dynamic "instant_restore_resource_group" {
     for_each = try(

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,7 @@ variable "vault" {
         timezone                       = optional(string, "UTC")
         policy_type                    = optional(string, "V1")
         instant_restore_retention_days = optional(number)
+        consistency_type               = optional(string)
         instant_restore_resource_group = optional(object({
           prefix = string
           suffix = optional(string)
@@ -255,6 +256,16 @@ variable "vault" {
       ) : true
     ])
     error_message = "For VM monthly retention: when include_last_days is true, weekdays and weeks must not be specified."
+  }
+
+  validation {
+    condition = alltrue([
+      for policy_name, policy in coalesce(var.vault.policies.vms, {}) :
+      policy.consistency_type == null || (
+        policy.consistency_type == "OnlyCrashConsistent" && policy.policy_type == "V2"
+      )
+    ])
+    error_message = "consistency_type must be 'OnlyCrashConsistent' and can only be specified when policy_type is 'V2'."
   }
 }
 


### PR DESCRIPTION
closes #90